### PR TITLE
chore: bump npm dependency version ranges to latest targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
-    "@types/node": "^20.11.19",
-    "allure-commandline": "^2.27.0",
-    "allure-playwright": "^2.14.1"
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^24.0.0",
+    "allure-commandline": "^2.34.1",
+    "allure-playwright": "^3.4.2"
   },
   "dependencies": {
     "playwright-lighthouse": "^4.0.0"


### PR DESCRIPTION
### Motivation
- Bring Playwright, Node type definitions, and Allure packages up to current stable ranges to receive bug fixes, improvements, and compatibility with newer Node/Playwright releases.

### Description
- Updated `package.json` devDependencies to `@playwright/test: ^1.55.0`, `@types/node: ^24.0.0`, `allure-commandline: ^2.34.1`, and `allure-playwright: ^3.4.2`, leaving `playwright-lighthouse` unchanged.

### Testing
- Ran `npm install` (failed with `403 Forbidden` from the npm registry), `npm ls --depth=0` (reported installed modules are invalid against new ranges), `npx playwright install --with-deps chromium` (failed due to apt/proxy `403` when fetching system packages), and `npx playwright test` (executed but all tests failed due to DNS/proxy errors to external APIs and missing Playwright browser binaries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eeb3ee97c832fa24c2ce24e21b6c5)